### PR TITLE
Load all objects on an as-needed basis

### DIFF
--- a/src/app/level/Level.ts
+++ b/src/app/level/Level.ts
@@ -30,6 +30,7 @@ export default class Level extends GenericRunner implements Master {
     private deathTimer = 0;
     private lastState : PlayerState;
     private options : LevelOptions;
+    private loaded : boolean = false;
 
     constructor(master : Master) {
         super(master);
@@ -60,6 +61,7 @@ export default class Level extends GenericRunner implements Master {
     }
 
     update() : void {
+        if (!this.loaded) return;
         this.camera = this.player.point;
         const truecamera = this.camera.round();
         this.drawables.position = new PIXI.Point(
@@ -102,7 +104,14 @@ export default class Level extends GenericRunner implements Master {
         this.objects.slice().forEach(e => this.removeObject(e));
         const data = Loader(this, 0);
         this.stage = data.stage;
-        data.objects.forEach( e => (this.addObject(e)) );
+
+        let count = 0;
+        data.objects.forEach( e => (e.then( obj => {
+            this.addObject(obj);
+            count++;
+            if (count === data.objects.length)
+                this.loaded = true;
+        })));
 
         this.player = new ActivePlayer(this.stage, this.lastState);
         this.addObject(this.player);

--- a/src/app/level/Loader.ts
+++ b/src/app/level/Loader.ts
@@ -4,22 +4,16 @@ import Terrain from './Terrain';
 import Level from './Level';
 import Stage from './Stage';
 
-import AspectTile from './objects/AspectTile';
-import Platform from './objects/Platform';
-import Square from './objects/Square';
-import SaveIcon from './objects/SaveIcon';
-import Bell from './objects/Bell';
-
 import Objects from '../data/Objects';
 import Worldfile from '../data/Worldfile';
 
 /**
  * Loader will load everything from the worldfile
  */
-export default function Loader(self : Level, index : number) : { terrain : Terrain, stage : Stage, objects : LevelObject[]} {
+export default function Loader(self : Level, index : number) : { terrain : Terrain, stage : Stage, objects : Promise<LevelObject>[]} {
     const terrain = new Terrain(self, Worldfile.levels[index]);
     const stage = new Stage(Worldfile.levels[index]);
-    const objects = Worldfile.levels[index].objects.map(e => parseObject(stage, e));
+    const objects = Worldfile.levels[index].objects.map(async e => await parseObject(stage, e));
     return {
         terrain,
         stage,
@@ -27,24 +21,28 @@ export default function Loader(self : Level, index : number) : { terrain : Terra
     }
 }
 
-function parseObject(stage : Stage, data : any[]) : LevelObject {
+async function parseObject(stage : Stage, data : any[]) : Promise<LevelObject> {
     const objdata = Objects[data[0]];
     const point = new Point(data[1], data[2]);
+
     if (objdata.type == "saveicon") {
+        const SaveIcon = (await import('./objects/SaveIcon')).default;
         return new SaveIcon(stage, point, objdata.rect);
     }
     else if (objdata.type == "bell") {
+        const Bell = (await import('./objects/Bell')).default;
         return new Bell(stage, point, objdata.rect);
     }
     else if (objdata.type == "aspecttile") {
+        const AspectTile = (await import('./objects/AspectTile')).default;
         return new AspectTile(stage, point, objdata.aspect, objdata.rect);
     }
     else if (objdata.type == "platform") {
+        const Platform = (await import('./objects/Platform')).default;
         return new Platform(stage, point, objdata.aspect, objdata.texture, objdata.rect, objdata.rect2, data[3], data[4]);
     }
     else if (objdata.type == "square") {
+        const Square = (await import('./objects/Square')).default;
         return new Square(stage, point, objdata.aspect, objdata.texture, objdata.rect, objdata.rect2, objdata.xor);        
     }
-
-    return null;
 };


### PR DESCRIPTION
Lazy loading is already used when we load the `Level` object. It's definitely possible, however, that not all objects will be needed in all levels, so it's worth seeing if we can break it up.

This might be overkill, I suppose we'll see if it causes more problems than it improves.